### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -90,7 +90,7 @@ class syntax_plugin_groupmgr extends DokuWiki_Syntax_Plugin {
     /**
      * Handle match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $data = array(null, $state, $pos);
         
         if (strlen($match) == 12)
@@ -121,7 +121,7 @@ class syntax_plugin_groupmgr extends DokuWiki_Syntax_Plugin {
     /**
      * Render it
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         global $auth;
         global $lang;
         global $INFO;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
